### PR TITLE
Remove unneeded require_once

### DIFF
--- a/src/DI/Bridge/ZendFramework1/Dispatcher.php
+++ b/src/DI/Bridge/ZendFramework1/Dispatcher.php
@@ -47,7 +47,6 @@ class Dispatcher extends Zend_Controller_Dispatcher_Standard
         if (!$this->isDispatchable($request)) {
             $controller = $request->getControllerName();
             if (!$this->getParam('useDefaultControllerAlways') && !empty($controller)) {
-                require_once 'Zend/Controller/Dispatcher/Exception.php';
                 throw new Zend_Controller_Dispatcher_Exception('Invalid controller specified (' . $request->getControllerName() . ')');
             }
 


### PR DESCRIPTION
Currently the ```require_once 'Zend/Controller/Dispatcher/Exception.php';``` statement forces a user to add the folder containing that exception class to the include-path. Since this class is ALREADY 'imported' at the beginning of the file with ```use Zend_Controller_Dispatcher_Exception;``` , this ```require_once``` statement is rather pointless. It did cause exceptions however when not using the proper include-paths:

```
#1 /project/vendor/zf1/zend-application/library/Zend/Application/Bootstrap/Bootstrap.php(105): Zend_Controller_Front->dispatch()
#2 /project/public/index.php(183): Zend_Application_Bootstrap_Bootstrap->run()
#3 {main}: Array
(
    [type] => 64
    [message] => require_once(): Failed opening required 'Zend/Controller/Dispatcher/Exception.php' (include_path='allThePaths here')
    [file] => /project/vendor/php-di/zf1-bridge/src/DI/Bridge/ZendFramework1/Dispatcher.php
    [line] => 50
)
```

**Motivation**
Classmap-based autoloading is preferred over using 'include-paths'. Also see http://framework.zend.com/manual/1.12/en/performance.classloading.html#performance.classloading.striprequires