### PR TITLE
Allow higher versions of PHP-DI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     },
     "require": {
-        "mnapoli/php-di": "~4.0"
+        "mnapoli/php-di": ">= 4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^3.7"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     },
     "require": {
-        "mnapoli/php-di": ">= 4.0"
+        "php-di/php-di": "~5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^3.7"


### PR DESCRIPTION
To experiment with PHP-DI 5.0, assuming they are compatible, first test run seems to work without proplems.