### PR TITLE
Make zf1 optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,13 @@
         }
     },
     "require": {
-        "mnapoli/php-di": "~4.0",
-        "zendframework/zendframework1": "1.12.*"
+        "mnapoli/php-di": "~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^3.7"
+    },
+    "suggest": {
+        "zendframework/zendframework1": "The complete Zend Framework 1",
+        "zf1/zend-controller": "The Zend Controller package only"
     }
 }


### PR DESCRIPTION
Make zf1 or zend-controller optional in case of having it already as it is already done on the 3.0.0 tag.