### PR TITLE
Allow using version 6 of PHP-DI.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     },
     "require": {
-        "php-di/php-di": "~5.0"
+        "php-di/php-di": "~5.0 || ~6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^3.7"


### PR DESCRIPTION
This bumps the dependency on PHP-DI to allow version 6.

Note: if this is released it should probably be a major version bump, because it will update PHP-DI to v6 (which has API changes and deprecations). However, it is still possible to use this with PHP-DI v5, by adding a hard dependency in their app to PHP-DI v5:

```sh
composer require php-di/php-di:"^5"
```